### PR TITLE
feat: add dynamic build palette and auto-register entities

### DIFF
--- a/src/dev/devMode.js
+++ b/src/dev/devMode.js
@@ -1,7 +1,7 @@
 // src/dev/devMode.js
 import * as THREE from 'three';
 import { DevCameraController } from './devCamera.js';
-import { DevUI } from './devUI.js';
+import { BuildUI } from './buildUI.js';
 import { InteractionManager, setupDragDrop } from './interaction.js';
 import { GridSystem } from './grid.js';
 import { GizmoManager } from './gizmo.js';
@@ -17,7 +17,7 @@ export class DevMode {
 
         // Controllers
         this.cameraController = new DevCameraController(app.renderer.camera, app.container);
-        this.ui = new DevUI(this);
+        this.ui = new BuildUI(this);
         this.interaction = new InteractionManager(this.app, this);
 
         // New Systems

--- a/src/world/entities/base.js
+++ b/src/world/entities/base.js
@@ -84,6 +84,10 @@ export class BaseEntity {
         };
     }
 
+    static get displayName() {
+        return this.type || this.name || 'Unknown Object';
+    }
+
     static fromSerialized(data) {
         // This will be handled by Registry to instantiate the class
         // and then we call init()

--- a/src/world/entities/buildings.js
+++ b/src/world/entities/buildings.js
@@ -19,6 +19,8 @@ export class SkyscraperEntity extends BaseEntity {
         this.type = 'skyscraper';
     }
 
+    static get displayName() { return 'Skyscraper'; }
+
     createMesh(params) {
         const h = params.height || (30 + Math.random() * 70);
         const w = params.width || 20;
@@ -90,6 +92,8 @@ export class ShopEntity extends BaseEntity {
         this.type = 'shop';
     }
 
+    static get displayName() { return 'Shop'; }
+
     createMesh(params) {
         const wBase = params.width || 20;
         const h = params.height || (8 + Math.random() * 6);
@@ -141,6 +145,8 @@ export class HouseEntity extends BaseEntity {
         super(params);
         this.type = 'house';
     }
+
+    static get displayName() { return 'House'; }
 
     createMesh(params) {
         const w = params.width || 15;

--- a/src/world/entities/creatures.js
+++ b/src/world/entities/creatures.js
@@ -10,6 +10,8 @@ export class BirdEntity extends BaseEntity {
         if (params.y === undefined) this.position.y = 5;
     }
 
+    static get displayName() { return 'Bird'; }
+
     createMesh(params) {
         const group = new THREE.Group();
         group.userData.startPos = this.position.clone();

--- a/src/world/entities/index.js
+++ b/src/world/entities/index.js
@@ -1,8 +1,7 @@
-// Export all for convenience
-export * from './base.js';
-export * from './registry.js';
-export * from './buildings.js';
-export * from './vehicles.js';
-export * from './creatures.js';
-export * from './nature.js';
-export * from './infrastructure.js';
+export { BaseEntity } from './base.js';
+export { EntityRegistry } from './registry.js';
+
+// Eagerly load all entity modules to trigger their registrations.
+// Vite will execute each module once, ensuring EntityRegistry is populated
+// without manual imports.
+import.meta.glob('./*.js', { eager: true });

--- a/src/world/entities/infrastructure.js
+++ b/src/world/entities/infrastructure.js
@@ -9,6 +9,8 @@ export class RoadEntity extends BaseEntity {
         this.type = 'road';
     }
 
+    static get displayName() { return 'Road'; }
+
     createMesh(params) {
         const w = params.width || 10;
         const l = params.length || 10;
@@ -41,6 +43,8 @@ export class RiverEntity extends BaseEntity {
         super(params);
         this.type = 'river';
     }
+
+    static get displayName() { return 'River'; }
 
     createMesh(params) {
         const w = params.width || 50;

--- a/src/world/entities/nature.js
+++ b/src/world/entities/nature.js
@@ -8,6 +8,8 @@ export class BushEntity extends BaseEntity {
         this.type = 'bush';
     }
 
+    static get displayName() { return 'Bush'; }
+
     createMesh(params) {
         const group = new THREE.Group();
 
@@ -52,6 +54,8 @@ export class OrangeTreeEntity extends BaseEntity {
         super(params);
         this.type = 'orangeTree';
     }
+
+    static get displayName() { return 'Orange Tree'; }
 
     createMesh(params) {
         const group = new THREE.Group();

--- a/src/world/entities/vehicles.js
+++ b/src/world/entities/vehicles.js
@@ -132,6 +132,8 @@ export class CarEntity extends VehicleEntity {
         this.baseSpeed = (CONFIG.DRONE.MAX_SPEED || 18.0) - 0.5;
     }
 
+    static get displayName() { return 'Car'; }
+
     createMesh(params) {
         const geoData = createSedanGeometry();
 
@@ -167,6 +169,8 @@ export class PickupTruckEntity extends CarEntity {
         this.waitTimer = 0;
         this.direction = 1; // 1 forward, -1 backward
     }
+
+    static get displayName() { return 'Pickup Truck'; }
 
     createMesh(params) {
         const geoData = createPickupGeometry();
@@ -280,6 +284,8 @@ export class BicycleEntity extends VehicleEntity {
         this.type = 'bicycle';
         this.baseSpeed = (CONFIG.DRONE.MAX_SPEED || 18.0) / 2;
     }
+
+    static get displayName() { return 'Bicycle'; }
 
     createMesh(params) {
         const partsGroup = createBicycleMesh();


### PR DESCRIPTION
## Summary
- auto-register entity modules via a Vite glob and keep registry/base exports intact
- add displayName metadata to entities for friendly palette labels
- replace the hardcoded Dev UI palette with Build UI that renders buttons from the EntityRegistry

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f6480f1ec8326b0c464c592eef376)