### PR TITLE
Add smart road placement tool

### DIFF
--- a/src/world/entities/infrastructure.js
+++ b/src/world/entities/infrastructure.js
@@ -11,26 +11,68 @@ export class RoadEntity extends BaseEntity {
 
     static get displayName() { return 'Road'; }
 
+    _createGeometry(width, length) {
+        const geo = new THREE.PlaneGeometry(width, length);
+        geo.rotateX(-Math.PI / 2);
+        geo.translate(0, 0.05, 0); // Lift up slightly
+        return geo;
+    }
+
+    _getTextureRepeat(width, length) {
+        const tileSize = 5;
+        const repeatX = Math.max(1, width / tileSize);
+        const repeatY = Math.max(1, length / tileSize);
+        return new THREE.Vector2(repeatX, repeatY);
+    }
+
+    _applyTextureScaling(map, width, length) {
+        if (!map) return;
+        const repeat = this._getTextureRepeat(width, length);
+        map.repeat.copy(repeat);
+        map.needsUpdate = true;
+    }
+
     createMesh(params) {
         const w = params.width || 10;
         const l = params.length || 10;
         this.params.width = w;
         this.params.length = l;
 
+        const map = TextureGenerator.createAsphalt();
+        this._applyTextureScaling(map, w, l);
+
         const mat = new THREE.MeshStandardMaterial({
-            map: TextureGenerator.createAsphalt(),
+            map,
             roughness: 0.9,
             color: 0x555555
         });
 
         // Use BufferGeometry rotation/translation to persist through BaseEntity.init's transform override
-        const geo = new THREE.PlaneGeometry(w, l);
-        geo.rotateX(-Math.PI / 2);
-        geo.translate(0, 0.05, 0); // Lift up slightly
+        const geo = this._createGeometry(w, l);
 
         const mesh = new THREE.Mesh(geo, mat);
         mesh.receiveShadow = true;
         return mesh;
+    }
+
+    updateDimensions({ width, length }) {
+        const w = width ?? this.params.width ?? 10;
+        const l = length ?? this.params.length ?? 10;
+        this.params.width = w;
+        this.params.length = l;
+
+        if (!this.mesh) return;
+
+        const geo = this._createGeometry(w, l);
+        this.mesh.geometry.dispose();
+        this.mesh.geometry = geo;
+        this.mesh.geometry.needsUpdate = true;
+
+        if (this.mesh.material?.map) {
+            this._applyTextureScaling(this.mesh.material.map, w, l);
+        }
+
+        this.mesh.userData.params = this.params;
     }
 
     createCollider() {


### PR DESCRIPTION
## Summary
- add road geometry helpers to support variable lengths and maintain asphalt texture tiling
- implement interactive road placement workflow that previews and finalizes road segments based on drag distance

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f6940b2b083268e0943ed1516ce5e)