### PR TITLE
Add smart road placement tool

### DIFF
--- a/src/world/entities/infrastructure.js
+++ b/src/world/entities/infrastructure.js
@@ -17,8 +17,13 @@ export class RoadEntity extends BaseEntity {
         this.params.width = w;
         this.params.length = l;
 
+        const asphalt = TextureGenerator.createAsphalt();
+        const repeatScale = 4;
+        asphalt.repeat.set(w / repeatScale, l / repeatScale);
+        asphalt.needsUpdate = true;
+
         const mat = new THREE.MeshStandardMaterial({
-            map: TextureGenerator.createAsphalt(),
+            map: asphalt,
             roughness: 0.9,
             color: 0x555555
         });


### PR DESCRIPTION
## Summary
- add drag-aware road placement that captures start and end points for variable lengths
- create road entities with computed length and rotation parameters
- adjust road texture tiling to avoid stretching on longer segments

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f6940b2b083268e0943ed1516ce5e)