### PR TITLE
⚡ Bolt: Cache PulseReactor textures

### DIFF
--- a/docs/performance/pulseReactor.md
+++ b/docs/performance/pulseReactor.md
@@ -1,0 +1,40 @@
+# Pulse Reactor Performance Optimization
+
+## System Overview
+The `PulseReactorEntity` (`src/world/entities/pulseReactor.js`) is a decorative world object featuring animated parts and emissive materials. It uses procedurally generated textures for its "core" (energy field) and "beam" (upward light beam) components.
+
+## The Bottleneck
+Previously, the `createEnergyTexture` and `createBeamTexture` methods created a new `THREE.CanvasTexture` (and underlying `HTMLCanvasElement` and `CanvasRenderingContext2D`) for *every instance* of the Pulse Reactor.
+
+This caused:
+- **Redundant Memory Usage**: Duplicate textures consuming GPU memory for identical content.
+- **CPU Overhead**: Expensive 2D canvas drawing operations running on every instantiation.
+- **Garbage Collection Pressure**: Short-lived canvas elements and contexts created during map loading.
+
+## The Solution
+We implemented **Module-Level Caching** for these textures.
+
+1.  **Module Variables**: Added `cachedEnergyTexture` and `cachedBeamTexture` variables in the module scope.
+2.  **Lazy Initialization**: The generation methods check if the cache is populated.
+    -   If cached: Return the existing texture.
+    -   If not: Generate the texture, store it in the cache, and return it.
+
+### Code Pattern
+```javascript
+let cachedTexture = null;
+
+createTexture() {
+    if (cachedTexture) return cachedTexture;
+
+    // ... expensive generation ...
+    const texture = new THREE.CanvasTexture(canvas);
+
+    cachedTexture = texture;
+    return texture;
+}
+```
+
+## Impact
+- **Memory**: O(1) texture memory usage regardless of instance count (was O(n)).
+- **Performance**: Significant reduction in instantiation time for maps with multiple Pulse Reactors.
+- **Verification**: Verified via `src/verification/verify_pulse_reactor_duplication.js`.

--- a/src/verification/verify_pulse_reactor_duplication.js
+++ b/src/verification/verify_pulse_reactor_duplication.js
@@ -1,0 +1,82 @@
+import { JSDOM } from 'jsdom';
+import * as THREE from 'three';
+
+// Setup JSDOM
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.HTMLCanvasElement = dom.window.HTMLCanvasElement;
+
+// Mock Canvas getContext
+const originalGetContext = global.HTMLCanvasElement.prototype.getContext;
+global.HTMLCanvasElement.prototype.getContext = function (type) {
+    if (type === '2d') {
+        return {
+            fillRect: () => {},
+            fillStyle: '',
+            strokeStyle: '',
+            lineWidth: 0,
+            beginPath: () => {},
+            moveTo: () => {},
+            lineTo: () => {},
+            stroke: () => {},
+            createLinearGradient: () => ({ addColorStop: () => {} }),
+        };
+    }
+    return originalGetContext.apply(this, arguments);
+};
+
+async function verify() {
+    // Dynamic import to ensure globals are established before module code runs
+    const { PulseReactorEntity } = await import('../world/entities/pulseReactor.js');
+
+    console.log('Creating PulseReactorEntity instances...');
+    const entity1 = new PulseReactorEntity();
+    entity1.init(); // This calls createMesh which calls createEnergyTexture/createBeamTexture
+
+    const entity2 = new PulseReactorEntity();
+    entity2.init();
+
+    // PulseReactorEntity stores emissive materials in _glowMaterials
+    // Order of push in createMesh:
+    // ...
+    // this._glowMaterials.push(beamMat, coreMat);
+    // ...
+
+    const beamMat1 = entity1._glowMaterials[0];
+    const coreMat1 = entity1._glowMaterials[1];
+
+    const beamMat2 = entity2._glowMaterials[0];
+    const coreMat2 = entity2._glowMaterials[1];
+
+    if (!beamMat1 || !coreMat1 || !beamMat2 || !coreMat2) {
+        console.error('Could not find materials in _glowMaterials');
+        process.exit(1);
+    }
+
+    const beamTex1 = beamMat1.map;
+    const coreTex1 = coreMat1.map;
+    const beamTex2 = beamMat2.map;
+    const coreTex2 = coreMat2.map;
+
+    console.log('Checking Beam Texture Identity...');
+    const beamShared = (beamTex1 === beamTex2);
+    console.log(`Beam Shared: ${beamShared}`);
+
+    console.log('Checking Core Texture Identity...');
+    const coreShared = (coreTex1 === coreTex2);
+    console.log(`Core Shared: ${coreShared}`);
+
+    if (beamShared && coreShared) {
+        console.log('SUCCESS: Textures are correctly shared/cached.');
+        process.exit(0);
+    } else {
+        console.error('FAILURE: Textures are NOT shared (Duplication detected).');
+        process.exit(1);
+    }
+}
+
+verify().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/world/entities/pulseReactor.js
+++ b/src/world/entities/pulseReactor.js
@@ -3,6 +3,9 @@ import { BaseEntity } from './base.js';
 import { EntityRegistry } from './registry.js';
 import { TextureGenerator } from '../../utils/textures.js';
 
+let cachedEnergyTexture = null;
+let cachedBeamTexture = null;
+
 export class PulseReactorEntity extends BaseEntity {
     constructor(params = {}) {
         super(params);
@@ -171,6 +174,8 @@ export class PulseReactorEntity extends BaseEntity {
     }
 
     createEnergyTexture() {
+        if (cachedEnergyTexture) return cachedEnergyTexture;
+
         const canvas = document.createElement('canvas');
         canvas.width = 256;
         canvas.height = 256;
@@ -208,10 +213,14 @@ export class PulseReactorEntity extends BaseEntity {
         texture.wrapS = THREE.RepeatWrapping;
         texture.wrapT = THREE.RepeatWrapping;
         texture.repeat.set(1, 1);
+
+        cachedEnergyTexture = texture;
         return texture;
     }
 
     createBeamTexture() {
+        if (cachedBeamTexture) return cachedBeamTexture;
+
         const canvas = document.createElement('canvas');
         canvas.width = 64;
         canvas.height = 256;
@@ -239,6 +248,8 @@ export class PulseReactorEntity extends BaseEntity {
         texture.colorSpace = THREE.SRGBColorSpace;
         texture.wrapS = THREE.ClampToEdgeWrapping;
         texture.wrapT = THREE.ClampToEdgeWrapping;
+
+        cachedBeamTexture = texture;
         return texture;
     }
 


### PR DESCRIPTION
Implements module-level caching for energy and beam textures in `PulseReactorEntity` to prevent redundant Canvas/Texture creation for each instance. Verified with `verify_pulse_reactor_duplication.js`.

💡 What:
- Introduced module-level variables `cachedEnergyTexture` and `cachedBeamTexture`.
- Updated `createEnergyTexture` and `createBeamTexture` to lazily initialize and return cached textures.
- Added `docs/performance/pulseReactor.md` documenting the optimization.
- Added `src/verification/verify_pulse_reactor_duplication.js` to prevent regression.

🎯 Why:
- Previous implementation created new `THREE.CanvasTexture` (and underlying HTMLCanvasElement) for every single instance.
- This caused linear memory growth O(n) and CPU spikes during instantiation.
- Optimization reduces texture memory usage to O(1) for this entity type.

📊 Impact:
- Reduces memory footprint and Garbage Collection pressure.
- Speeds up scene loading when multiple Pulse Reactors are present.

---
*PR created automatically by Jules for task [3441988749083576209](https://jules.google.com/task/3441988749083576209) started by @DanteMarone*