### PR TITLE
🎨 Palette: Accessible Persistent Tabs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -3,3 +3,7 @@
 ## 2024-05-23 - Outliner Visibility Toggle Missing Styles
 **Learning:** The Outliner's visibility toggle was implemented as an unstyled `div` with no content, rendering it effectively invisible to users. This highlights the risk of relying on class names that are assumed to exist but aren't verified in CSS.
 **Action:** When implementing UI controls, always verify the visual representation exists. Prefer semantic `<button>` elements with explicit text/icon content over empty divs relying on background images unless strictly necessary.
+
+## 2024-05-22 - [Palette Tabs] Learning: DOM Rebuilding Destroys Focus
+**Learning:** Rebuilding the entire innerHTML of a container (`tabsDiv.innerHTML = ''`) destroys the currently focused element, resetting focus to the body. This makes keyboard navigation impossible as the user loses their place after every interaction.
+**Action:** Separation of concern: Split "Initial Creation" from "State Update". Only update attributes (`aria-selected`, classes) on existing elements instead of recreating them.

--- a/docs/ux/palette_tabs.md
+++ b/docs/ux/palette_tabs.md
@@ -1,0 +1,26 @@
+# Palette Tabs Interaction
+
+## UX Pattern
+**Accessible Persistent Tabs**
+
+The Asset Palette categories ("All", "Residential", etc.) are implemented as a persistent tab list.
+Instead of rebuilding the tabs whenever a category is selected (which destroys keyboard focus), the tabs are created once and their state (`aria-selected`, `active` class) is toggled.
+
+## User Story
+*   **As a** keyboard user,
+*   **I want** to navigate through asset categories using the Tab key or Arrow keys and select one with Enter,
+*   **So that** I can filter assets without using a mouse.
+
+*   **As a** screen reader user,
+*   **I want** to hear which tab is currently selected,
+*   **So that** I know which filter is applied.
+
+## Accessibility Features
+*   **Role="tablist"**: The container identifies itself as a list of tabs.
+*   **Role="tab"**: Each category button identifies as a tab.
+*   **Aria-Selected**: The active tab has `aria-selected="true"`, others have `"false"`.
+*   **Persistent Focus**: Because tabs are not destroyed on refresh, focus remains on the selected tab after activation, allowing users to easily move to the next tab.
+*   **Semantic Button**: Used `<button>` elements for native keyboard support (Enter/Space to activate).
+
+## Visuals
+The tabs maintain the existing visual design (grey text, transparent background) but gain semantic structure underneath.

--- a/src/dev/ui/palette.js
+++ b/src/dev/ui/palette.js
@@ -9,6 +9,7 @@ export class Palette {
         this.thumbnailRenderer = thumbnailRenderer;
         this.content = null;
         this.tabsDiv = null;
+        this.tabElements = new Map();
         this.selectedCategory = 'All';
         this.searchQuery = '';
         this.thumbnails = new Map();
@@ -28,7 +29,10 @@ export class Palette {
 
         const tabsDiv = document.createElement('div');
         tabsDiv.className = 'dev-palette-tabs';
+        tabsDiv.setAttribute('role', 'tablist');
+        tabsDiv.setAttribute('aria-label', 'Asset Categories');
         this.tabsDiv = tabsDiv;
+        this.createTabs();
         header.appendChild(tabsDiv);
 
         // Search Input
@@ -57,22 +61,41 @@ export class Palette {
         this.refresh();
     }
 
-    refresh() {
-        if (!this.content) return;
-        this.tabsDiv.innerHTML = '';
-        this.content.innerHTML = '';
-
+    createTabs() {
         const categories = ['All', 'Residential', 'Infrastructure', 'Vehicles', 'Nature', 'Props'];
         categories.forEach(cat => {
-            const tab = document.createElement('div');
-            tab.className = `dev-palette-tab ${this.selectedCategory === cat ? 'active' : ''}`;
+            const tab = document.createElement('button');
+            tab.className = 'dev-palette-tab';
             tab.textContent = cat;
+
+            // A11y
+            tab.setAttribute('role', 'tab');
             tab.onclick = () => {
                 this.selectedCategory = cat;
                 this.refresh();
             };
+
+            this.tabElements.set(cat, tab);
             this.tabsDiv.appendChild(tab);
         });
+    }
+
+    refresh() {
+        if (!this.content) return;
+
+        // Update Tabs State
+        this.tabElements.forEach((tab, cat) => {
+             const isActive = (cat === this.selectedCategory);
+             if (isActive) {
+                 tab.classList.add('active');
+                 tab.setAttribute('aria-selected', 'true');
+             } else {
+                 tab.classList.remove('active');
+                 tab.setAttribute('aria-selected', 'false');
+             }
+        });
+
+        this.content.innerHTML = '';
 
         // Populate Grid
         EntityRegistry.registry.forEach((Cls, type) => {

--- a/src/dev/ui/palette.test.js
+++ b/src/dev/ui/palette.test.js
@@ -1,0 +1,86 @@
+import { describe, it, before, beforeEach, after } from 'node:test';
+import { strict as assert } from 'assert';
+import { JSDOM } from 'jsdom';
+import { EntityRegistry } from '../../world/entities/registry.js';
+
+// Setup JSDOM
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+global.document = dom.window.document;
+global.window = dom.window;
+global.HTMLElement = dom.window.HTMLElement;
+global.HTMLInputElement = dom.window.HTMLInputElement;
+global.HTMLDivElement = dom.window.HTMLDivElement;
+global.HTMLButtonElement = dom.window.HTMLButtonElement;
+
+// Import Palette after global mocks
+import { Palette } from './palette.js';
+
+describe('Palette Component', () => {
+    let container;
+    let palette;
+    let mockDevMode;
+    let mockThumbnailRenderer;
+
+    before(() => {
+        // Setup Registry
+        class MockEntity { static displayName = 'Test House'; }
+        EntityRegistry.register('test_house', MockEntity);
+    });
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+
+        mockDevMode = {
+            setPlacementMode: () => {},
+            interaction: { onDragStart: () => {}, onDragEnd: () => {} }
+        };
+        mockThumbnailRenderer = {
+            generate: () => 'data:image/png;base64,fake'
+        };
+
+        palette = new Palette(mockDevMode, container, mockThumbnailRenderer);
+    });
+
+    after(() => {
+        document.body.innerHTML = '';
+        EntityRegistry.registry.clear();
+    });
+
+    it('should create tabs and grid', () => {
+        assert.ok(palette.tabsDiv, 'Tabs container created');
+        assert.ok(palette.content, 'Content grid created');
+        // Initial refresh is called in constructor
+        assert.ok(palette.tabsDiv.children.length > 0, 'Should have category tabs');
+    });
+
+    it('should NOT destroy tabs on refresh (Accessibility Focus Preservation)', () => {
+        const tabs = palette.tabsDiv.children;
+        const firstTab = tabs[0];
+
+        // Trigger refresh by selecting a category
+        // Find a tab that is NOT the currently selected one (default 'All')
+        // But clicking 'All' again also triggers refresh.
+        // Let's click the second one.
+        const secondTab = tabs[1];
+        if (secondTab) {
+            secondTab.click();
+        } else {
+             // Fallback if only 1 tab
+             firstTab.click();
+        }
+
+        const newTabs = palette.tabsDiv.children;
+        const newFirstTab = newTabs[0];
+
+        assert.strictEqual(firstTab, newFirstTab, 'Tab elements should persist across refreshes to maintain focus');
+    });
+
+    it('should have correct ARIA roles', () => {
+        assert.equal(palette.tabsDiv.getAttribute('role'), 'tablist', 'Container should have role=tablist');
+        const tab = palette.tabsDiv.children[0];
+        assert.equal(tab.tagName, 'BUTTON', 'Tabs should be <button> elements');
+        assert.equal(tab.getAttribute('role'), 'tab', 'Tabs should have role=tab');
+        assert.ok(tab.hasAttribute('aria-selected'), 'Tabs should have aria-selected attribute');
+    });
+});

--- a/src/test_all.js
+++ b/src/test_all.js
@@ -5,5 +5,6 @@ import './gameplay/rings.test.js';
 import './world/timeCycle.test.js';
 import './world/colliders.test.js';
 import './dev/history.test.js';
+import './dev/ui/palette.test.js';
 
 console.log('\n✨ All tests completed successfully.');

--- a/style.css
+++ b/style.css
@@ -759,8 +759,12 @@ body {
 .dev-palette-tab {
     padding: 6px 12px;
     cursor: pointer;
-    border-right: 1px solid #444;
     color: #888;
+    background: transparent;
+    border: none;
+    border-right: 1px solid #444;
+    font: inherit;
+    text-align: left;
 }
 .dev-palette-tab:hover { background: #333; color: #fff; }
 .dev-palette-tab.active { background: #333; color: white; border-bottom: 2px solid #2196F3; }


### PR DESCRIPTION
💡 **What:**
Refactored the Dev Mode Asset Palette to use accessible, persistent tabs for category selection.

🎯 **Why:**
Previously, selecting a category rebuilt the entire tab DOM, causing keyboard focus to be lost and preventing efficient keyboard navigation. It also lacked semantic ARIA roles.

📸 **Changes:**
- **Before:** Tabs were `div`s with `onclick`, recreated on every click.
- **After:** Tabs are `<button>`s with `role="tab"`, created once. `refresh()` only toggles `aria-selected` and `active` classes.
- **Visuals:** Identical to previous design (verified via screenshot).

♿ **Accessibility:**
- Added `role="tablist"` and `role="tab"`.
- Added `aria-selected="true/false"`.
- Validated keyboard focus persistence using JSDOM tests.

📚 **Documentation:**
[docs/ux/palette_tabs.md](docs/ux/palette_tabs.md)

---
*PR created automatically by Jules for task [2422666576851140403](https://jules.google.com/task/2422666576851140403) started by @DanteMarone*