### PR TITLE
🔭 Scout: Updated postprocessing to v6.38.2

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -6,7 +6,7 @@ This document tracks the current versions of key dependencies in the project.
 | Package | Version | Description |
 | :--- | :--- | :--- |
 | `three` | `^0.181.2` | 3D rendering engine. |
-| `postprocessing` | `^6.38.0` | Post-processing effects for Three.js. |
+| `postprocessing` | `^6.38.2` | Post-processing effects for Three.js. |
 
 ## Development Dependencies
 | Package | Version | Description |
@@ -15,4 +15,5 @@ This document tracks the current versions of key dependencies in the project.
 | `playwright` | `^1.57.0` | End-to-end testing framework. |
 
 ## Update Log
+- **2026-01-27:** Updated `postprocessing` from `6.38.0` to `6.38.2`.
 - **2024-05-22:** Updated `vite` from `7.2.7` to `7.3.0`.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "jsdom": "^27.4.0",
-    "postprocessing": "^6.38.0",
+    "postprocessing": "^6.38.2",
     "three": "^0.181.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,12 @@ importers:
 
   .:
     dependencies:
-      fflate:
-        specifier: ^0.8.2
-        version: 0.8.2
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0
       postprocessing:
-        specifier: ^6.38.0
-        version: 6.38.0(three@0.181.2)
+        specifier: ^6.38.2
+        version: 6.38.2(three@0.181.2)
       three:
         specifier: ^0.181.2
         version: 0.181.2
@@ -409,9 +406,6 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
-
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -485,10 +479,10 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postprocessing@6.38.0:
-    resolution: {integrity: sha512-tisx8XN/PWTL3uXz2mt8bjlMS1wiOUSCK3ixi4zjwUCFmP8XW8hNhXwrxwd2zf2VmCyCQ3GUaLm7GLnkkBbDsQ==}
+  postprocessing@6.38.2:
+    resolution: {integrity: sha512-7DwuT7Tkst41ZjSj287g7C9c5/D3Xx5rMgBosg0dadbUPoZD2HNzkadKPol1d2PJAoI9f+Jeh1/v9YfLzpFGVw==}
     peerDependencies:
-      three: '>= 0.157.0 < 0.182.0'
+      three: '>= 0.157.0 < 0.183.0'
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -871,8 +865,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  fflate@0.8.2: {}
-
   fsevents@2.3.2:
     optional: true
 
@@ -959,7 +951,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postprocessing@6.38.0(three@0.181.2):
+  postprocessing@6.38.2(three@0.181.2):
     dependencies:
       three: 0.181.2
 


### PR DESCRIPTION
Updated `postprocessing` dependency from `6.38.0` to `6.38.2` to resolve an alpha blending regression. Verified with unit tests and build. Updated dependency documentation.

---
*PR created automatically by Jules for task [3168412319338960801](https://jules.google.com/task/3168412319338960801) started by @DanteMarone*